### PR TITLE
bin: add FRR support

### DIFF
--- a/bin/k8s-topo
+++ b/bin/k8s-topo
@@ -122,6 +122,8 @@ def parse_endpoints(devices, endpoints, link, idx):
             device = devices.get(device_name, Host(device_name))
         elif "qrtr" in device_name.lower():
             device = devices.get(device_name, Quagga(device_name))
+        elif "frr" in device_name.lower():
+            device = devices.get(device_name, FRR(device_name))
         elif "xrv" in device_name.lower():
             device = devices.get(device_name, XRV(device_name))
         elif "vmx" in device_name.lower():
@@ -648,6 +650,12 @@ class Quagga(Device):
         self.conf_path = "/etc/quagga"
         self.startup_file = "Quagga.conf"
 
+class FRR(Device):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.image = "frrouting/frr:v7.4.0"
+        self.conf_path = "/etc/frr"
+        self.startup_file = "frr.conf"
 
 class XRV(Device):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Add support for FRR as a choice of virtual router.

It's hardcoded to the latest release but I may push a followup patch if FRR makes a docker tag that points to the latest stable release.

Platform support:
i386
amd64
armv6
armv7
arm64
ppc64le
s390x