### PR TITLE
adapt init-wait for srlinux containers

### DIFF
--- a/init-wait/entrypoint.sh
+++ b/init-wait/entrypoint.sh
@@ -6,7 +6,7 @@ SLEEP=${2:-0}
 int_calc () 
 {
     index=0
-    for i in $(ls -1v /sys/class/net/ | grep 'eth\|ens\|eno'); do
+    for i in $(ls -1v /sys/class/net/ | grep 'eth\|ens\|eno\|^e[0-9]'); do
       let index=index+1
     done
     MYINT=$index


### PR DESCRIPTION
srlinux containers use a named dataplane interfaces 

`eX-Y` - where
* `X` - linecard number
* `Y` - port number

this change makes init-wait to sense those interfaces


Output from the init-wait container of a srlinux pod

```
/ # ls -1v /sys/class/net/ | grep 'eth\|ens\|eno\|^e[0-9]'
eth0
e1-1
e1-2
```